### PR TITLE
Added force remove function as a custom function in go-sdk library

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -189,6 +189,8 @@ type StateManager interface {
 	Set(stateName string, value any) error
 	// Remove is to remove state store with @stateName
 	Remove(stateName string) error
+	// Force Remove is to remove state store with @stateName
+	ForceRemove(stateName string) error
 	// Contains is to check if state store contains @stateName
 	Contains(stateName string) (bool, error)
 	// Save is to saves the state cache of this actor instance to state store component by calling api of daprd.
@@ -216,6 +218,8 @@ type StateManagerContext interface {
 	SetWithTTL(ctx context.Context, stateName string, value any, ttl time.Duration) error
 	// Remove is to remove state store with @stateName
 	Remove(ctx context.Context, stateName string) error
+	// Force Remove is to remove state store with @stateName
+	ForceRemove(ctx context.Context, stateName string) error
 	// Contains is to check if state store contains @stateName
 	Contains(ctx context.Context, stateName string) (bool, error)
 	// Save is to saves the state cache of this actor instance to state store component by calling api of daprd.


### PR DESCRIPTION
Due to an issue in the Dapr SDK library, the `.Remove()` function does not effectively remove states from the redis state store upon server restarts, leading to the persistence of stale states. The problem is especially noticeable in the `ContainsContext` nested function in the `.Remove()` function. Actually, its not fetching the state even if the state is existed in the redis (This problem arises only if the server restarts). To fix this, I have added a new function called `.ForceRemove()` . This function forcefully removes the state by directly checking if the state key exists in redis. If the key exists, the state is removed without errors. If the key does not exist, the function gracefully ignores the operation to prevent any potential errors.